### PR TITLE
Bugfix: make use of table prefix if specified in the configuration.

### DIFF
--- a/FileModel.php
+++ b/FileModel.php
@@ -40,7 +40,7 @@ class FileModel extends \yii\db\ActiveRecord
      */
     public static function tableName()
     {
-        return 'uploaded_file';
+        return '{{%uploaded_file}}';
     }
 
     /**


### PR DESCRIPTION
Your migration script creates a prefixed table, meanwhile the model does not use the prefix. This commit fixes this small bug.